### PR TITLE
feat: pm2를 이용한 무중단 배포 설정 추가 - #25

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -13,7 +13,15 @@ permissions:
 # 배포 생명주기마다 실행되는 hook
 # scripts/{hook}.sh
 hooks:
-  AfterInstall:
-    - location: scripts/after-install.sh
+  BeforeInstall:
+    - location: scripts/before_install.sh
       timeout: 300
-      runas: root
+      runas: ubuntu
+  AfterInstall:
+    - location: scripts/after_install.sh
+      timeout: 300
+      runas: ubuntu
+  ApplicationStart:
+    - location: scripts/start_server.sh
+      timeout: 300
+      runas: ubuntu

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  apps: [
+    {
+      name: 'wagu-front',
+      script: 'npm',
+      args: 'run start',
+      instances: 'max', // 모든 CPU 코어 사용 (ec2의 cpu)
+      exec_mode: 'cluster', // 클러스터 모드로 실행
+      watch: true, // 파일 변경 감지
+      max_memory_restart: '1G', // 메모리 제한 (해당 메모리 이상을 사용하면 재시작)
+      env: {
+        NODE_ENV: 'production',
+      },
+    },
+  ],
+};

--- a/scripts/after-install.sh
+++ b/scripts/after-install.sh
@@ -1,1 +1,4 @@
-echo "> AfterInstall Hook : install done !!"
+cd /home/ubuntu/wagu-front
+
+npm install
+npm run build

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd /home/ubuntu/wagu-front
+# 기존 파일 삭제 (선택 사항)
+rm -rf *

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd /home/ubuntu/wagu-front
+pm2 reload ecosystem.config.js --env production
+pm2 save


### PR DESCRIPTION
## 🩱 Summary
#25 
> ec2에서 pm2로 next 프로젝트를 실행하게되는데
ecosystem.config.js를 통해 pm2가 파일의 변경점을 감지하게되고 reload를 실행하게 된다. 단 cluster모드라 자식프로세스가 생성되고 자식프로세스가 실행이 되었을때 reload로 자식이 마스터프로세스가 된다

after와 before sh는 code deploy가 ec2에 접근해 실행하는 명령어이다.

## ⛔️ 주의사항

>

## 🧞‍♂️ Etc..

>
