### PR TITLE
투표가 진행된 이후에도 선택한 store 상태 유지되도록 구현 - #137

### DIFF
--- a/src/app/share/page.tsx
+++ b/src/app/share/page.tsx
@@ -33,6 +33,7 @@ import PostsOfMap from '@/app/map/_components/PostsOfMap';
 import Heading from '@/components/ui/Heading';
 import ImageFill from '@/components/ui/ImageFill';
 import { KingSVG } from '@public/newDesign/vote';
+import { usePostsOfStore, useSelectedStore, useVotedStore } from '@/stores';
 
 import s from './page.module.scss';
 
@@ -94,11 +95,17 @@ export default function SharePage() {
   const [subscribers, setSubscribers] = useState<Subscriber[]>([]);
 
   const [usersProfile, setUsersProfile] = useState(new Map());
-  const [selectedStore, setSelectedStore] = useState<StoreResponse | null>();
+  // before zustand
+  // const [selectedStore, setSelectedStore] = useState<StoreResponse | null>();
+  const { selectedStore, setSelectedStore } = useSelectedStore();
 
-  const [votedStores, setVotedStores] = useState<any[]>([]);
+  // before zustand
+  // const [votedStores, setVotedStores] = useState<any[]>([]);
+  const { votedStores, setVotedStores } = useVotedStore();
   const [selectedStoreId, setSelectedStoreId] = useState<any>();
-  const [postsOfStore, setPostsOfStore] = useState<any[]>([]);
+  // before zustand
+  // const [postsOfStore, setPostsOfStore] = useState<any[]>([]);
+  const { postsOfStore, setPostsOfStore } = usePostsOfStore();
 
   const [isVoteStart, setIsVoteStart] = useState<boolean>(false);
   const [isVoteEnd, setIsVoteEnd] = useState<boolean>(false);
@@ -548,7 +555,9 @@ export default function SharePage() {
         storeId,
       );
       setVotedStores(
-        votedStores.filter(({ storeId: curStoreId }) => curStoreId != storeId),
+        votedStores.filter(
+          ({ storeId: curStoreId }) => curStoreId != Number(storeId),
+        ),
       );
       broadcastUpdateVoteListSIG();
       alert(succMsg);

--- a/src/components/StoreCard.tsx
+++ b/src/components/StoreCard.tsx
@@ -7,6 +7,7 @@ import { MouseEvent, MouseEventHandler, useState } from 'react';
 
 import { UserIcon } from '@/components/UserIcon';
 import ImageFill from '@/components/ui/ImageFill';
+import { VotedStoreResponse } from '@/types';
 
 import s from './StoreCard.module.scss';
 
@@ -31,9 +32,7 @@ export default function StoreCards({ stores }: { stores: Store[] }) {
   );
 }
 
-export interface VotedStoreCardProps {
-  storeId: number;
-  storeName: string;
+export interface VotedStoreCardProps extends VotedStoreResponse {
   handleRemoveVotedStore: MouseEventHandler<HTMLButtonElement>;
 }
 
@@ -75,7 +74,7 @@ export function VotedStoreCards({
   stores,
   handleRemoveVotedStore,
 }: {
-  stores: VotedStoreCardProps[];
+  stores: VotedStoreResponse[];
   handleRemoveVotedStore: MouseEventHandler<HTMLButtonElement>;
 }) {
   return (

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -4,6 +4,7 @@ import {
   MapVertexes,
   ProfileWithoutFollowResponse,
   SignupDetails,
+  VotedStoreResponse,
 } from '@/types';
 
 interface ProfileDetailsResponse {
@@ -21,17 +22,6 @@ interface ShareMapPublishSessionResponse {
 
 interface AIAutoReviewResponse {
   menuContent: string;
-}
-
-interface VotedStoreResponse {
-  storeId: number;
-  storeName: string;
-  menuImage: {
-    id: number;
-    url: string;
-  };
-  postCount: number;
-  menuName: string;
 }
 
 type SuccessMessageResponse = Promise<string>;

--- a/src/stores/index.tsx
+++ b/src/stores/index.tsx
@@ -1,25 +1,38 @@
+import {
+  PostOfStoreResponse,
+  StoreResponse,
+  VotedStoreResponse,
+} from '@/types';
 import { create } from 'zustand';
 
-interface UseVoteDoneCountStore {
-  voteDoneCount: number;
-  voteDoneUserNames: string[];
-  increaseVoteDoneCount: () => void;
-  addVoteDoneUserName: (userName: string) => void;
-  setVoteDoneUserNames: (userNames: string[]) => void;
+interface UseSelectedStore {
+  selectedStore: StoreResponse | null;
+  setSelectedStore: (selectedStore: StoreResponse) => void;
 }
 
-export const useVoteDoneCountStore = create<UseVoteDoneCountStore>((set) => ({
-  voteDoneCount: 1,
-  voteDoneUserNames: [],
-  increaseVoteDoneCount: () => {
-    set((state) => ({ voteDoneCount: state.voteDoneCount + 1 }));
+interface UsePostsOfStore {
+  postsOfStore: PostOfStoreResponse[];
+  setPostsOfStore: (postsOfStore: PostOfStoreResponse[]) => void;
+}
+
+interface UseVotedStore {
+  votedStores: VotedStoreResponse[];
+  setVotedStores: (votedStores: VotedStoreResponse[]) => void;
+}
+
+export const useSelectedStore = create<UseSelectedStore>((set) => ({
+  selectedStore: null,
+  setSelectedStore: (selectedStore: StoreResponse) => set({ selectedStore }),
+}));
+
+export const usePostsOfStore = create<UsePostsOfStore>((set) => ({
+  postsOfStore: [],
+  setPostsOfStore: (postsOfStore: PostOfStoreResponse[]) => {
+    set({ postsOfStore });
   },
-  addVoteDoneUserName: (userName: string) => {
-    set((state) => ({
-      voteDoneUserNames: [...state.voteDoneUserNames, userName],
-    }));
-  },
-  setVoteDoneUserNames: (userNames: string[]) => {
-    set({ voteDoneUserNames: [...userNames] });
-  },
+}));
+
+export const useVotedStore = create<UseVotedStore>((set) => ({
+  votedStores: [],
+  setVotedStores: (votedStores: VotedStoreResponse[]) => set({ votedStores }),
 }));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,9 +34,9 @@ export interface AddPostProps {
 }
 
 export interface PostOfStoreResponse {
-  storeName: string;
   postId: number;
   postMainMenu: string;
+  storeName: string;
   category: CategoriesEN;
   menuImage: PostImage;
   menuPrice: number;
@@ -86,4 +86,15 @@ export interface StoreResponse {
   posx: number;
   posy: number;
   liveStore: boolean;
+}
+
+export interface VotedStoreResponse {
+  storeId: number;
+  storeName: string;
+  menuImage: {
+    id: number;
+    url: string;
+  };
+  postCount: number;
+  menuName: string;
 }


### PR DESCRIPTION
## 🩱 Summary

> #137

zustand 상태관리를 이용해 vote를 하는 중에도 다른 게시글을 갔다왓을때 store에 대한 상태가 유지되도록 변경했습니다.

## ⛔️ 주의사항

>

## 🧞‍♂️ Etc..

>
